### PR TITLE
12/12 第三次验收整改

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,0 @@
-config:
-  architecture: ppc64le
-  kernel: 5.4.0-131-generic
-  kernel-package: krl.tar.gz
-  VersaSDS-DEB: versasds1_1.1_ppc64el.deb

--- a/main.py
+++ b/main.py
@@ -40,10 +40,10 @@ def main():
     parser.add_argument('-d', '--display', action='store_true',
                         help=argparse.SUPPRESS)
     parser.add_argument('-v', '--version', action='store_true',
-                        help='Show version information')
+                        help='show version information')
     args = parser.parse_args()
     
-    logger = Logger("log")
+    logger = Logger("vsdsinstaller-k")
     re_in = ReplacementInstallation(logger)
     
     if args.replace:

--- a/replacement_installation.py
+++ b/replacement_installation.py
@@ -107,13 +107,7 @@ class ReplacementInstallation:
                 result = self.base.com(command_b)
                 self.logger.log(f"执行指令：{command_b}. \n执行结果：{result.stdout}")
                 
-                # 倒计时
-                print("等待 5 秒钟...")
-                for i in range(5, 0, -1):
-                    print(f"\r倒计时: {i}秒", end="")
-                    sys.stdout.flush()
-                    time.sleep(1)
-                print("\n等待结束")
+                time.sleep(5)
 
                 # 生成 initramfs 映像
                 command_create = f"update-initramfs -c -k {expected_kernel_version}"
@@ -150,7 +144,7 @@ class ReplacementInstallation:
                     sys.exit()
                 else:
                     print("更新 grub 成功")
-                    
+
             current_kernel_version = self.base.com("uname -r").stdout.strip()
             print(f"内核版本更新完成，当前内核版本为：{current_kernel_version}")
         else:

--- a/replacement_installation.py
+++ b/replacement_installation.py
@@ -72,6 +72,10 @@ class ReplacementInstallation:
         # 检查当前内核版本是否符合预期版本
         if current_kernel_version not in expected_kernel_version: # 不符合 继续后续步骤
             print(f"当前内核版本为：{current_kernel_version}，不符合预期版本，准备更新内核")
+            
+            print("执行检查 copymods 方法")
+            self.check_copymods()
+
             kernel_package_name = self.config.get('kernel-package').strip()
             tar_path = os.path.join(current_dir, kernel_package_name)
             # 检查内核安装包是否存在于当前路径
@@ -81,12 +85,9 @@ class ReplacementInstallation:
             except FileNotFoundError as e:
                 print(e)
                 sys.exit() 
-            
-            print("执行检查 copymods 方法")
-            self.check_copymods()
 
             # 解压内核安装包
-            command = f"tar -xzvf {kernel_package_name}"
+            command = f"sudo tar -xzvf {kernel_package_name}"
             print("解压内核安装包中")
             result = self.base.com(command)
             self.logger.log(f"执行指令：{command}. \n执行结果：{result.stdout}")
@@ -100,17 +101,17 @@ class ReplacementInstallation:
                 # print(f"{tar_path}")
                 
                 # 拷贝内核文件及内核模块
-                command_a = f"cp {tar_path}/boot/* /boot/"
+                command_a = f"sudo cp {tar_path}/boot/* /boot/"
                 result = self.base.com(command_a)
-                self.logger.log(f"执行指令：{command_a}. \n执行结果：{result.stdout}")
-                command_b = f"cp -r {tar_path}/lib/modules/5.4.0-131-generic /lib/modules/"
+                self.logger.log(f"执行指令：{command_a}. \n执行结果：{result.returncode}")
+                command_b = f"sudo cp -r {tar_path}/lib/modules/5.4.0-131-generic /lib/modules/"
                 result = self.base.com(command_b)
-                self.logger.log(f"执行指令：{command_b}. \n执行结果：{result.stdout}")
+                self.logger.log(f"执行指令：{command_b}. \n执行结果：{result.returncode}")
                 
                 time.sleep(5)
 
                 # 生成 initramfs 映像
-                command_create = f"update-initramfs -c -k {expected_kernel_version}"
+                command_create = f"sudo update-initramfs -c -k {expected_kernel_version}"
                 result = self.base.com(command_create)
                 self.logger.log(f"执行指令：{command_create}. \n执行结果：{result.stdout}")
                 if result.returncode == 0:
@@ -181,10 +182,10 @@ class ReplacementInstallation:
             sys.exit()
 
         print("执行 apt update, 请耐心等待")
-        self.base.com("apt update")
+        self.base.com("sudo apt update")
 
         # 安装依赖包和 Java
-        command = "apt install -y flex xmlto po4a xsltproc asciidoctor python3-setuptools help2man unzip default-jre openjdk-11-jre-headless"
+        command = "sudo apt install -y flex xmlto po4a xsltproc asciidoctor python3-setuptools help2man unzip default-jre openjdk-11-jre-headless"
         print("开始安装依赖包和 Java，网络原因可能会花费较多时间")
         result = self.base.com(command)
         self.logger.log(f"执行指令：{command}. \n执行结果：{result.stdout}")
@@ -197,7 +198,7 @@ class ReplacementInstallation:
             sys.exit()
 
         # 安装 VersaSDS (DRBD/LINSTOR)
-        command = f"dpkg -i {VersaSDS_DEB}"
+        command = f"sudo dpkg -i {VersaSDS_DEB}"
         print("开始安装VersaSDS")
         result = self.base.com(command)
         self.logger.log(f"执行指令：{command}. \n执行结果：{result.stdout}")

--- a/replacement_installation.py
+++ b/replacement_installation.py
@@ -103,17 +103,25 @@ class ReplacementInstallation:
                 # 拷贝内核文件及内核模块
                 command_a = f"sudo cp {tar_path}/boot/* /boot/"
                 result = self.base.com(command_a)
-                self.logger.log(f"执行指令：{command_a}. \n执行结果：{result.returncode}")
+                self.logger.log(f"执行指令：{command_a}. \n执行结果：{result.stdout}\n返回码：{result.returncode}")
+                if result.returncode != 0:
+                    print("替换内核失败，程序终止")
+                    sys.exit()
                 command_b = f"sudo cp -r {tar_path}/lib/modules/5.4.0-131-generic /lib/modules/"
                 result = self.base.com(command_b)
-                self.logger.log(f"执行指令：{command_b}. \n执行结果：{result.returncode}")
-                
+                self.logger.log(f"执行指令：{command_b}. \n执行结果：{result.stdout}\n返回码：{result.returncode}")
+                if result.returncode != 0:
+                    print("替换内核失败，程序终止")
+                    sys.exit()
+
                 time.sleep(5)
 
                 # 生成 initramfs 映像
+                print(f"更新 initramfs 中")
                 command_create = f"sudo update-initramfs -c -k {expected_kernel_version}"
                 result = self.base.com(command_create)
                 self.logger.log(f"执行指令：{command_create}. \n执行结果：{result.stdout}")
+                print(f"执行生成 initramfs 映像. \n执行结果：{result.stdout}")
                 if result.returncode == 0:
                     command_ls = f"ls /boot | grep initrd.img-{expected_kernel_version}"
                     result = self.base.com(command_ls)
@@ -146,8 +154,7 @@ class ReplacementInstallation:
                 else:
                     print("更新 grub 成功")
 
-            current_kernel_version = self.base.com("uname -r").stdout.strip()
-            print(f"内核版本更新完成，当前内核版本为：{current_kernel_version}")
+            print(f"内核版本更新完成")
         else:
             print(f"当前内核版本为：{current_kernel_version}，已是预期内核版本")
 

--- a/vsdsinstaller-k_config.yaml
+++ b/vsdsinstaller-k_config.yaml
@@ -1,0 +1,5 @@
+config:
+  architecture: x86_64
+  kernel: 5.15.0-88-generic
+  kernel-package: krl.tar.gz
+  VersaSDS-DEB: versasds1_1.1_ppc64el.deb

--- a/vsdsinstaller-k_config.yaml
+++ b/vsdsinstaller-k_config.yaml
@@ -1,5 +1,5 @@
 config:
-  architecture: x86_64
-  kernel: 5.15.0-88-generic
+  architecture: ppc64le
+  kernel: 5.4.0-131-generic
   kernel-package: krl.tar.gz
   VersaSDS-DEB: versasds1_1.1_ppc64el.deb


### PR DESCRIPTION
1. 调整了更换内核方法，添加了拷贝内核文件及内核模块后，暂停程序五秒再运行的功能
2. 增加了检查 copymods 方法
3. 添加了 apt update 执行的提示
4. 增加了解压后文件夹识别方法
5. 增加 “更换内核成功“ 的提示
6. 调整了日志文件名，使其命名规范符合<工具名>_年-月-日.log